### PR TITLE
Default to token auth and VAULT_ADDR env

### DIFF
--- a/core/common.go
+++ b/core/common.go
@@ -25,7 +25,7 @@ func ResolveAlias(v *viper.Viper, alias string) *url.URL {
 	vurl := v.GetString(vkey)
 	log.Printf("Checking for alias: %v", vkey)
 	if vurl != "" {
-		log.Printf("using alias: %s\n", vurl)
+		log.Printf("Found an alias: %s\n", vurl)
 		return ParseURL(vurl)
 	}
 	return nil


### PR DESCRIPTION
In the case where someone is using syncrets for the very first time:
```
syncrets list vault://localhost:8200/secret/
```

It would be nice to avoid this error when there is no ~/.syncrets/syncrets.yml config file:
```
Authenication failed: No valid auth.method configured for 'localhost'
```

Defaulting to `token` auth and looking for a `VAULT_TOKEN` environment variable will be better and not a surprise for users used to the behaviour of the vault CLI.