### PR TITLE
Lookup alias if URL matches

### DIFF
--- a/backend/vault.go
+++ b/backend/vault.go
@@ -334,13 +334,17 @@ func (v *Vault) resolveArgs(args []string) error {
 		return errors.New("cannot parse url")
 	}
 	v.path = v.origURL.Path
-	v.name = v.origURL.Hostname()
-	u := core.ResolveAlias(v.viper, v.name)
+	alias := core.ReverseLookupAlias(v.viper, v.origURL)
+	if alias == "" {
+		alias = v.origURL.Hostname()
+	}
+	u := core.ResolveAlias(v.viper, alias)
 	if u != nil {
 		v.url = u
 	} else {
 		v.url = v.origURL
 	}
+	v.name = alias
 	log.Printf("%s using url: %v\n", v.name, v.url)
 	return nil
 }

--- a/core/common.go
+++ b/core/common.go
@@ -30,3 +30,16 @@ func ResolveAlias(v *viper.Viper, alias string) *url.URL {
 	}
 	return nil
 }
+
+// ReverseLookupAlias from a URL
+func ReverseLookupAlias(v *viper.Viper, u *url.URL) string {
+	urlMap := make(map[string]string, 1)
+	aliases := v.GetStringMap("vault")
+	for alias := range aliases {
+		vkey := fmt.Sprintf("vault.%s.url", alias)
+		aliasURL := v.GetString(vkey)
+		urlMap[aliasURL] = alias
+	}
+	uStr := fmt.Sprintf("%s://%s:%s", u.Scheme, u.Hostname(), u.Port())
+	return urlMap[uStr]
+}

--- a/core/common_test.go
+++ b/core/common_test.go
@@ -1,0 +1,35 @@
+package core
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+)
+
+func getViper(file string) *viper.Viper {
+	v := viper.New()
+	v.SetConfigFile(file)
+	v.ReadInConfig()
+	return v
+}
+
+var reverseLookupAliasTests = []struct {
+	url    string
+	expect string
+}{
+	{"http://localhost:8201", "vault-a"},
+	{"https://localhost:8201", ""},   // wrong scheme
+	{"https://unknown-tls", ""},      // unknown URL
+	{"https://unknown-tls:8200", ""}, // unknown URL
+}
+
+func TestReverseLookupAlias_Valid(t *testing.T) {
+	v := getViper("../testdata/syncrets-test1.yml")
+	for _, tc := range reverseLookupAliasTests {
+		u, _ := url.Parse(tc.url)
+		alias := ReverseLookupAlias(v, u)
+		assert.Equal(t, tc.expect, alias)
+	}
+}


### PR DESCRIPTION
If the user happens to use a fully-qualified URL as an argument that matches an entry/alias in the syncrets config then it would be helpful to use the matching config, example:
```
syncrets list https://localhost:8201/secret
```
... will behave the same way as:
```
syncrets list vault://vault-a/secret/
```
... assuming that the syncrets config has a definition for `vault-a` with a `url` set to `https://localhost:8201`:
```
vault:
    vault-a:
        url: "https://localhost:8201"
        auth:
            method: token
        token:
            file: ~/.syncrets/.vault-a-token
```